### PR TITLE
Make #getId public

### DIFF
--- a/src/main/java/fr/delthas/skype/Group.java
+++ b/src/main/java/fr/delthas/skype/Group.java
@@ -35,7 +35,7 @@ public class Group {
     skype.sendGroupMessage(this, message);
   }
 
-  String getId() {
+  public String getId() {
     return id;
   }
 


### PR DESCRIPTION
This is a very useful id for identifying different groups, needs to be public!